### PR TITLE
Fix fallback to website on location image load

### DIFF
--- a/vite-web.config.ts
+++ b/vite-web.config.ts
@@ -63,7 +63,23 @@ export default defineConfig({
       },
       workbox: {
         globPatterns: ["**/*.{js,html,css,ico,png,svg,webp}"],
-        globIgnores: ["**/locations/*.webp"],
+        navigateFallbackDenylist: [/^\/locations\/.*\.webp$/],
+        runtimeCaching: [
+          {
+            urlPattern: /^\/locations\/.*\.webp$/,
+            handler: "CacheFirst",
+            options: {
+              cacheName: "locations-images-cache",
+              expiration: {
+                maxEntries: 100,
+                maxAgeSeconds: 60 * 60 * 24 * 365, // <== 365 days
+              },
+              cacheableResponse: {
+                statuses: [200],
+              },
+            },
+          },
+        ],
       },
     }),
   ],


### PR DESCRIPTION
Instead of `globIgnores`, the correct way to ignore the location images is to use [navigateFallbackDenylist](https://vite-pwa-org.netlify.app/workbox/generate-sw.html#exclude-routes).
These images will be cached by the service worker.